### PR TITLE
fix: patch 4 security vulnerabilities in SQL handling and HTTP auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,11 @@ This mode exposes an HTTP server, which is useful for testing, debugging, or dir
 # Run the server in HTTP mode on the default host and port (127.0.0.1:3000)
 uv run adbpg-mcp-server --transport http
 
-# Specify a custom host and port
-uv run adbpg-mcp-server --transport http --host 0.0.0.0 --port 3000
+# Specify a custom host and port with authentication
+uv run adbpg-mcp-server --transport http --host 0.0.0.0 --port 3000 --auth-token your-secret-token
 ```
+
+> **Security:** When binding to `0.0.0.0` or any network-accessible address, always set an authentication token via `--auth-token` or the `MCP_AUTH_TOKEN` environment variable. Without a token, the `/mcp` endpoint is open to unauthenticated access. Clients must include the `Authorization: Bearer <token>` header in all requests.
 
 ## MCP Integration
 
@@ -121,6 +123,7 @@ To integrate this server with a parent MCP client, add the following configurati
       "ADBPG_USER": "username",
       "ADBPG_PASSWORD": "password",
       "ADBPG_DATABASE": "database",
+      "MCP_AUTH_TOKEN": "your-secret-token",
       "GRAPHRAG_API_KEY": "graphrag llm api key",
       "GRAPHRAG_BASE_URL": "graphrag llm base url",
       "GRAPHRAG_LLM_MODEL": "graphrag llm model name",
@@ -241,6 +244,10 @@ MCP Server requires the following environment variables to connect to AnalyticDB
 - `ADBPG_USER`: Database username
 - `ADBPG_PASSWORD`: Database password
 - `ADBPG_DATABASE`: Database name
+
+For HTTP transport mode, the following optional variable enables endpoint authentication:
+
+- `MCP_AUTH_TOKEN`: Bearer token for HTTP endpoint authentication (can also be set via `--auth-token` CLI argument). **Strongly recommended** when binding to non-loopback addresses.
 
 MCP Server requires the following environment variables to initialize graphRAG and llm memory server：
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "adbpg-mcp-server"
-version = "2.0.0"
+version = "2.0.1"
 description = "AnalyticDB PostgreSQL MCP Server serves as a universal interface between AI Agents and AnalyticDB PostgreSQL databases. It enables seamless communication between AI Agents and AnalyticDB PostgreSQL, helping AI Agents retrieve database metadata and execute SQL operations."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/adbpg_mcp_server/__main__.py
+++ b/src/adbpg_mcp_server/__main__.py
@@ -29,12 +29,17 @@ def main():
         default = 3000,
         help = "Port to bind the HTTP server to (default: 3000)."
     )
-    
+    http_group.add_argument(
+        "--auth-token",
+        default = None,
+        help = "Bearer token for HTTP endpoint authentication. Can also be set via MCP_AUTH_TOKEN env var."
+    )
+
     args = parser.parse_args()
     print(f"Starting ADBPG MCP Server with transport {args.transport}")
 
     if args.transport == "http":
-        run_http_server(host=args.host, port=args.port)
+        run_http_server(host=args.host, port=args.port, auth_token=args.auth_token)
     elif args.transport == "stdio":
         run_stdio_server()
     else:

--- a/src/adbpg_mcp_server/adbpg_basic_operation.py
+++ b/src/adbpg_mcp_server/adbpg_basic_operation.py
@@ -1,5 +1,7 @@
 # mcp_server/basic_operation.py
+import re
 import psycopg
+from psycopg import sql
 import logging
 from pydantic import AnyUrl
 from mcp.types import Resource, ResourceTemplate, Tool
@@ -8,6 +10,18 @@ from typing import Tuple
 
 
 logger = logging.getLogger(__name__)
+
+_IDENTIFIER_RE = re.compile(r'^[A-Za-z_][A-Za-z0-9_]*$')
+
+def _validate_identifier(name: str, label: str = "identifier") -> str:
+    if not name or not _IDENTIFIER_RE.match(name):
+        raise ValueError(f"Invalid {label}: {name!r}")
+    return name
+
+def _strip_sql_comments(text: str) -> str:
+    text = re.sub(r'/\*.*?\*/', '', text, flags=re.DOTALL)
+    text = re.sub(r'--[^\n]*', '', text)
+    return text.strip()
 
 async def list_resources() -> list[Resource]:
     """列出可用的基本资源"""
@@ -66,8 +80,10 @@ async def read_resource(uri: AnyUrl, db: DatabaseManager) -> str:
                 return "\n".join([f"{table[0]} ({table[1]})" for table in cursor.fetchall()])
                 
             elif len(path_parts) == 3 and path_parts[2] == "ddl":
-                schema, table = path_parts[0], path_parts[1]
-                query = f"SELECT pg_get_ddl('{schema}.{table}'::regclass);"
+                schema, table = _validate_identifier(path_parts[0], "schema"), _validate_identifier(path_parts[1], "table")
+                query = sql.SQL("SELECT pg_get_ddl({}.{}::regclass);").format(
+                    sql.Identifier(schema), sql.Identifier(table)
+                )
                 cursor.execute(query)
                 ddl = cursor.fetchone()
                 return ddl[0] if ddl else f"No DDL found for {schema}.{table}"
@@ -120,41 +136,62 @@ def get_basic_tools() -> list[Tool]:
         ),
     ]
 
-async def call_basic_tool(name: str, arguments: dict, db: DatabaseManager) -> Tuple[str, dict, bool]:
+async def call_basic_tool(name: str, arguments: dict, db: DatabaseManager) -> Tuple:
     """
     准备执行基础工具的SQL和参数。
-    返回 (query_string, params, needs_json_agg)
+    返回 (query, params, fetch_mode)
+    fetch_mode: "select" — fetch rows and build JSON from column names;
+                "json" — fetch single JSON value from first row;
+                None — no result to fetch (DML/DDL/ANALYZE).
     """
-    query, params, needs_json_agg = None, None, False
-    
+    query, params, fetch_mode = None, None, None
+
     if name == "execute_select_sql":
         query_text = arguments.get("query")
-        if not query_text or not query_text.strip().upper().startswith("SELECT"):
+        stripped = _strip_sql_comments(query_text) if query_text else ""
+        if not stripped or not stripped.upper().startswith("SELECT"):
             raise ValueError("Query must be a SELECT statement")
-        query = f"SELECT json_agg(row_to_json(t)) FROM ({query_text.rstrip(';')}) AS t"
-        needs_json_agg = True
+        if ";" in stripped.rstrip(";"):
+            raise ValueError("Query must not contain multiple statements")
+        query = stripped.rstrip(";")
+        fetch_mode = "select"
     elif name == "execute_dml_sql":
         query = arguments.get("query")
-        if not query or not any(query.strip().upper().startswith(k) for k in ["INSERT", "UPDATE", "DELETE"]):
+        stripped = _strip_sql_comments(query) if query else ""
+        if not stripped or not any(stripped.upper().startswith(k) for k in ["INSERT", "UPDATE", "DELETE"]):
             raise ValueError("Query must be a DML statement (INSERT, UPDATE, DELETE)")
+        if ";" in stripped.rstrip(";"):
+            raise ValueError("Query must not contain multiple statements")
+        query = stripped.rstrip(";")
     elif name == "execute_ddl_sql":
         query = arguments.get("query")
-        if not query or not any(query.strip().upper().startswith(k) for k in ["CREATE", "ALTER", "DROP", "TRUNCATE"]):
+        stripped = _strip_sql_comments(query) if query else ""
+        if not stripped or not any(stripped.upper().startswith(k) for k in ["CREATE", "ALTER", "DROP", "TRUNCATE"]):
             raise ValueError("Query must be a DDL statement (CREATE, ALTER, DROP)")
+        if ";" in stripped.rstrip(";"):
+            raise ValueError("Query must not contain multiple statements")
+        query = stripped.rstrip(";")
     elif name == "analyze_table":
         schema, table = arguments.get("schema"), arguments.get("table")
         if not all([schema, table]):
             raise ValueError("Schema and table are required")
-        query = f"ANALYZE {schema}.{table}"
+        _validate_identifier(schema, "schema")
+        _validate_identifier(table, "table")
+        query = sql.SQL("ANALYZE {}.{}").format(
+            sql.Identifier(schema), sql.Identifier(table)
+        )
     elif name == "explain_query":
         query_text = arguments.get("query")
-        if not query_text:
+        stripped = _strip_sql_comments(query_text) if query_text else ""
+        if not stripped:
             raise ValueError("Query is required")
-        query = f"EXPLAIN (FORMAT JSON) {query_text}"
-        needs_json_agg = True # The output is already a single JSON value in a single row
+        if ";" in stripped.rstrip(";"):
+            raise ValueError("Query must not contain multiple statements")
+        query = f"EXPLAIN (FORMAT JSON) {stripped.rstrip(';')}"
+        fetch_mode = "json"
 
     if query is None:
         raise ValueError(f"Unknown basic tool: {name}")
 
-    return (query, params, needs_json_agg)
+    return (query, params, fetch_mode)
 

--- a/src/adbpg_mcp_server/adbpg_config.py
+++ b/src/adbpg_mcp_server/adbpg_config.py
@@ -5,7 +5,7 @@ from dotenv import load_dotenv
 
 logger = logging.getLogger(__name__)
 
-SERVER_VERSION = "0.2.0"
+SERVER_VERSION = "2.0.1"
 
 try:
     load_dotenv()

--- a/src/adbpg_mcp_server/server_http.py
+++ b/src/adbpg_mcp_server/server_http.py
@@ -1,10 +1,12 @@
 import requests
 import logging
 import json
+import hmac
 import click
 import contextlib
 import uvicorn
 import sys
+import os
 import mcp.types as types
 from pydantic import AnyUrl
 from collections.abc import AsyncIterator
@@ -13,9 +15,26 @@ from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
 from mcp.types import Resource, Tool, TextContent, ResourceTemplate
 from starlette.applications import Starlette
 from starlette.routing import Mount
+from starlette.responses import JSONResponse
+from starlette.middleware import Middleware
+from starlette.middleware.base import BaseHTTPMiddleware
 from .adbpg import DatabaseManager
 from . import adbpg_basic_operation, adbpg_graphrag, adbpg_memory
 from .adbpg_config import settings
+
+
+class BearerAuthMiddleware(BaseHTTPMiddleware):
+    """Validates Bearer token on all requests when MCP_AUTH_TOKEN is set."""
+
+    def __init__(self, app, token: str):
+        super().__init__(app)
+        self.token = token
+
+    async def dispatch(self, request, call_next):
+        auth_header = request.headers.get("Authorization", "")
+        if not auth_header.startswith("Bearer ") or not hmac.compare_digest(auth_header[7:], self.token):
+            return JSONResponse({"error": "Unauthorized"}, status_code=401)
+        return await call_next(request)
 
 
 db_manager: DatabaseManager | None = None
@@ -68,7 +87,14 @@ def initialize_services():
 
 
 
-def run_http_server(host, port):
+def run_http_server(host, port, auth_token=None):
+
+    auth_token = auth_token or os.getenv("MCP_AUTH_TOKEN")
+    if not auth_token:
+        logger.warning(
+            "No authentication token configured. Set MCP_AUTH_TOKEN or use --auth-token "
+            "to protect the HTTP endpoint."
+        )
 
     # 创建MCP服务端
     app = Server("adbpg-mcp-server")
@@ -132,13 +158,18 @@ def run_http_server(host, port):
         try:
             # 分发到 Basic Operation
             if name in [t.name for t in adbpg_basic_operation.get_basic_tools()]:
-                query, params, needs_json_agg = await adbpg_basic_operation.call_basic_tool(name, arguments, db_manager)
+                query, params, fetch_mode = await adbpg_basic_operation.call_basic_tool(name, arguments, db_manager)
                 conn = db_manager.get_basic_connection()
                 with conn.cursor() as cursor:
                     cursor.execute(query, params)
-                    if needs_json_agg:
+                    if fetch_mode == "select":
+                        columns = [desc[0] for desc in cursor.description]
+                        rows = cursor.fetchall()
+                        json_result = [dict(zip(columns, row)) for row in rows]
+                        return [TextContent(type="text", text=json.dumps(json_result, ensure_ascii=False, indent=2, default=str))]
+                    elif fetch_mode == "json":
                         json_result = cursor.fetchone()[0]
-                        return [TextContent(type="text", text=json.dumps(json_result, ensure_ascii=False, indent=2))]
+                        return [TextContent(type="text", text=json.dumps(json_result, ensure_ascii=False, indent=2, default=str))]
                     else:
                         return [TextContent(type="text", text="Tool executed successfully.")]
 
@@ -194,10 +225,15 @@ def run_http_server(host, port):
                 logger.info("ADBPG MCP Server shutting down…")
     
     # 将MCP服务挂载到/mcp路径上，用户访问整个路径时，就会进入刚才创建的MCP HTTP会话管理器
+    middleware = []
+    if auth_token:
+        middleware.append(Middleware(BearerAuthMiddleware, token=auth_token))
+
     starlette_app = Starlette(
         debug=False,
         routes=[Mount("/mcp", app=handle_streamable_http)],
         lifespan=lifespan,
+        middleware=middleware,
     )
 
     # 利用uvicorn启动ASGI服务器并监听指定端口

--- a/src/adbpg_mcp_server/server_stdio.py
+++ b/src/adbpg_mcp_server/server_stdio.py
@@ -113,13 +113,18 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent]:
     try:
         # 分发到 Basic Operation
         if name in [t.name for t in adbpg_basic_operation.get_basic_tools()]:
-            query, params, needs_json_agg = await adbpg_basic_operation.call_basic_tool(name, arguments, db_manager)
+            query, params, fetch_mode = await adbpg_basic_operation.call_basic_tool(name, arguments, db_manager)
             conn = db_manager.get_basic_connection()
             with conn.cursor() as cursor:
                 cursor.execute(query, params)
-                if needs_json_agg:
+                if fetch_mode == "select":
+                    columns = [desc[0] for desc in cursor.description]
+                    rows = cursor.fetchall()
+                    json_result = [dict(zip(columns, row)) for row in rows]
+                    return [TextContent(type="text", text=json.dumps(json_result, ensure_ascii=False, indent=2, default=str))]
+                elif fetch_mode == "json":
                     json_result = cursor.fetchone()[0]
-                    return [TextContent(type="text", text=json.dumps(json_result, ensure_ascii=False, indent=2))]
+                    return [TextContent(type="text", text=json.dumps(json_result, ensure_ascii=False, indent=2, default=str))]
                 else:
                     return [TextContent(type="text", text="Tool executed successfully.")]
 


### PR DESCRIPTION
- Add Bearer token authentication middleware for HTTP /mcp endpoint, configurable via --auth-token or MCP_AUTH_TOKEN env var
- Fix SQL injection in DDL/ANALYZE by using psycopg.sql.Identifier instead of f-string interpolation
- Remove unsafe json_agg(row_to_json()) subquery wrapping of user SQL; execute SELECT directly and convert results to JSON in Python
- Strip SQL comments before keyword validation to prevent bypass via /* comment */ prefix
- Reject multi-statement queries (embedded semicolons)
- Bump version to 2.0.1